### PR TITLE
Support different value types

### DIFF
--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -188,6 +188,14 @@ class TestStore(unittest.TestCase):
         with self.assertRaises(ValueError):
             self.store.add_directory('/this/path/doesnt/exist', {})
 
+    def test_bad_metadata(self):
+        with self.assertRaises(TypeError):
+            self.store.add_file(self.t('file1.bin'), {'key': ()})
+        with self.assertRaises(ValueError):
+            self.store.add_file(
+                    self.t('file1.bin'),
+                    {'key': {'type': 'blah', 'value': ()}})
+
     def test_open(self):
         h = self.store.add_file(self.t('file1.bin'), {'findme': 'here'})
         entry = self.store.query_one({'findme': 'here'})


### PR DESCRIPTION
In the same way _make_conditions() is there to support different query types, _make_value() should be added to support different value types.

The only use for this right now would be to add `{'type': 'str', 'date': 'utc'}`. If I can't find anything else to add there might not be much need for this.
