### PR TITLE
Support for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python: 2.7
 env:
   - TOX_ENV=py26
   - TOX_ENV=py27
+  - TOX_ENV=py32
   - TOX_ENV=py33
   - TOX_ENV=coverage
 install:

--- a/file_archive/__init__.py
+++ b/file_archive/__init__.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import os
 import shutil
 import warnings

--- a/file_archive/compat.py
+++ b/file_archive/compat.py
@@ -14,6 +14,8 @@ quote_str:
 StringIO
 """
 
+from __future__ import division, unicode_literals
+
 from abc import ABCMeta
 import hashlib
 

--- a/file_archive/compat.py
+++ b/file_archive/compat.py
@@ -62,7 +62,7 @@ else:
 
 
 def quote_str(s):
-    return "'%s'" % s.replace("\\", "\\\\").replace("'", "\\'")
+    return '"%s"' % s.replace("\\", "\\\\").replace('"', '\\"')
 
 
 try:

--- a/file_archive/compat.py
+++ b/file_archive/compat.py
@@ -25,6 +25,9 @@ __all__ = ['PY3', 'string_types', 'int_types', 'sha1', 'unicode_type',
            'quote_str', 'StringIO', 'BytesIO']
 
 
+PY3 = sys.version_info >= (3, 0)
+
+
 try:
     string_types = basestring
 except NameError:

--- a/file_archive/compat.py
+++ b/file_archive/compat.py
@@ -11,17 +11,18 @@ quote_str:
  * Version of 2's repr() that won't add a 'u' prefix (different versions of
    Python put it or not)
 
-StringIO
+BytesIO, StringIO
 """
 
 from __future__ import division, unicode_literals
 
 from abc import ABCMeta
 import hashlib
+import sys
 
 
-__all__ = ['string_types', 'int_types', 'sha1', 'unicode_type', 'quote_str',
-           'StringIO']
+__all__ = ['PY3', 'string_types', 'int_types', 'sha1', 'unicode_type',
+           'quote_str', 'StringIO', 'BytesIO']
 
 
 try:
@@ -68,10 +69,13 @@ def quote_str(s):
 try:
     # CPython 2
     from cStringIO import StringIO
+    BytesIO = StringIO
 except ImportError:
     try:
         # Python 2
-        from StringIO import StringIO
+        from StringIO import StringIO as BytesIO
+        BytesIO = StringIO
     except ImportError:
         # Python 3
         from io import StringIO
+        from io import BytesIO

--- a/file_archive/compat.py
+++ b/file_archive/compat.py
@@ -16,7 +16,6 @@ BytesIO, StringIO
 
 from __future__ import division, unicode_literals
 
-from abc import ABCMeta
 import hashlib
 import sys
 
@@ -28,20 +27,19 @@ __all__ = ['PY3', 'string_types', 'int_types', 'sha1', 'unicode_type',
 PY3 = sys.version_info >= (3, 0)
 
 
-try:
+if not PY3:
     string_types = basestring
-except NameError:
-    string_types = str
+    int_types = int, long
+    unicode_type = unicode
 
-try:
-    long
-except NameError:
-    int_types = int
+    from StringIO import StringIO
+    BytesIO = StringIO
 else:
-    class int_types:
-        __metaclass__ = ABCMeta
-    int_types.register(int)
-    int_types.register(long)
+    string_types = str
+    int_types = int
+    unicode_type = str
+
+    from io import StringIO, BytesIO
 
 
 class sha1(object):
@@ -59,26 +57,5 @@ class sha1(object):
         return self._hash.hexdigest()
 
 
-if bytes == str:
-    unicode_type = unicode
-else:
-    unicode_type = str
-
-
 def quote_str(s):
     return '"%s"' % s.replace("\\", "\\\\").replace('"', '\\"')
-
-
-try:
-    # CPython 2
-    from cStringIO import StringIO
-    BytesIO = StringIO
-except ImportError:
-    try:
-        # Python 2
-        from StringIO import StringIO as BytesIO
-        BytesIO = StringIO
-    except ImportError:
-        # Python 3
-        from io import StringIO
-        from io import BytesIO

--- a/file_archive/database.py
+++ b/file_archive/database.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import sqlite3
 
 from .compat import string_types, int_types

--- a/file_archive/entry_point.py
+++ b/file_archive/entry_point.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import codecs
 import locale
 import sys

--- a/file_archive/entry_point.py
+++ b/file_archive/entry_point.py
@@ -10,7 +10,7 @@ from file_archive.trans import setup_translation
 
 def entry_point():
     # Locale
-    locale.setlocale(locale.LC_ALL, '')
+    locale.setlocale(locale.LC_ALL, str(''))
 
     # Encoding for output streams
     if str == bytes:

--- a/file_archive/main.py
+++ b/file_archive/main.py
@@ -24,9 +24,9 @@ def parse_query_metadata(args):
         for a in args:
             k = a.split('=', 1)
             if len(k) != 2:
-                sys.stderr.write(_(u"Metadata should have format key=value, "
-                                   u"key=type:value (eg. age=int:23) or "
-                                   u"key=type:req (eg. age=int:>21)\n"))
+                sys.stderr.write(_("Metadata should have format key=value, "
+                                   "key=type:value (eg. age=int:23) or "
+                                   "key=type:req (eg. age=int:>21)\n"))
                 sys.exit(1)
             k, v = k
             if ':' in v:
@@ -42,10 +42,10 @@ def parse_query_metadata(args):
                 elif t == 'str':
                     req = 'equal'
                 else:
-                    sys.stderr.write(_(u"Metadata has unknown type '{t}'! "
-                                       u"Only 'str' and 'int' are supported.\n"
-                                       u"If you meant a string with a ':', "
-                                       u"use 'str:mystring'", t=t))
+                    sys.stderr.write(_("Metadata has unknown type '{t}'! "
+                                       "Only 'str' and 'int' are supported.\n"
+                                       "If you meant a string with a ':', "
+                                       "use 'str:mystring'", t=t))
                     sys.exit(1)
             else:
                 t = 'str'
@@ -54,13 +54,13 @@ def parse_query_metadata(args):
                 v = v.decode(locale.getpreferredencoding())
             if k in metadata:
                 if t != metadata[k]['type']:
-                    sys.stderr.write(_(u"Differing types for conditions on "
-                                       u"key {k}: {t1}, {t2}\n",
+                    sys.stderr.write(_("Differing types for conditions on "
+                                       "key {k}: {t1}, {t2}\n",
                                        k=k, t1=metadata[k]['type'], t2=t))
                     sys.exit(1)
                 if req in metadata[k]:
-                    sys.stderr.write(_(u"Multiple conditions {cond} on key "
-                                       u"{k}\n",
+                    sys.stderr.write(_("Multiple conditions {cond} on key "
+                                       "{k}\n",
                                        cond=req, k=k))
                     sys.exit(1)
                 metadata[k][req] = v
@@ -76,8 +76,8 @@ def parse_new_metadata(args):
     for a in args:
         k = a.split('=', 1)
         if len(k) != 2:
-            sys.stderr.write(_(u"Metadata should have format key=value or "
-                               u"key=type:value (eg. age=int:23)\n"))
+            sys.stderr.write(_("Metadata should have format key=value or "
+                               "key=type:value (eg. age=int:23)\n"))
             sys.exit(1)
         k, v = k
         if ':' in v:
@@ -93,10 +93,10 @@ def parse_new_metadata(args):
             if isinstance(v, bytes):
                 v = v.decode(locale.getpreferredencoding())
         else:
-            sys.stderr.write(_(u"Metadata has unknown type '{t}'! Only 'str' "
-                               u"and 'int' are supported.\n"
-                               u"If you meant a string with a ':', use "
-                               u"'str:mystring'", t=t))
+            sys.stderr.write(_("Metadata has unknown type '{t}'! Only 'str' "
+                               "and 'int' are supported.\n"
+                               "If you meant a string with a ':', use "
+                               "'str:mystring'", t=t))
             sys.exit(1)
         metadata[k] = {'type': t, 'value': v}
     return metadata
@@ -108,11 +108,11 @@ def cmd_add(store, args):
     add <filename> [key1=value1] [...]
     """
     if not args:
-        sys.stderr.write(_(u"Missing filename\n"))
+        sys.stderr.write(_("Missing filename\n"))
         sys.exit(1)
     filename = args[0]
     if not os.path.exists(filename):
-        sys.stderr.write(_(u"Path does not exist: {path}\n", path=filename))
+        sys.stderr.write(_("Path does not exist: {path}\n", path=filename))
         sys.exit(1)
     metadata = parse_new_metadata(args[1:])
     if os.path.isdir(filename):
@@ -154,7 +154,7 @@ def cmd_query(store, args):
             del args[0]
             break
         else:
-            sys.stderr.write(_(u"Unknown option: {opt}\n", opt=args[0]))
+            sys.stderr.write(_("Unknown option: {opt}\n", opt=args[0]))
             sys.exit(1)
         del args[0]
     h, metadata = parse_query_metadata(args)
@@ -216,7 +216,7 @@ def cmd_print(store, args):
             del args[0]
             break
         else:
-            sys.stderr.write(_(u"Unknown option: {opt}\n", opt=args[0]))
+            sys.stderr.write(_("Unknown option: {opt}\n", opt=args[0]))
             sys.exit(1)
         del args[0]
     h, metadata = parse_query_metadata(args)
@@ -224,21 +224,21 @@ def cmd_print(store, args):
         try:
             entry = store.get(h)
         except KeyError:
-            sys.stderr.write(_(u"Hash not found\n"))
+            sys.stderr.write(_("Hash not found\n"))
             sys.exit(2)
     else:
         entries = store.query(metadata)
         try:
             entry = next(entries)
         except StopIteration:
-            sys.stderr.write(_(u"No match found\n"))
+            sys.stderr.write(_("No match found\n"))
             sys.exit(2)
         try:
             next(entries)
         except StopIteration:
             pass
         else:
-            sys.stderr.write(_(u"Warning: more matching files exist\n"))
+            sys.stderr.write(_("Warning: more matching files exist\n"))
     if meta:
         for k, v in entry.metadata.items():
             if k == 'hash':
@@ -251,7 +251,7 @@ def cmd_print(store, args):
             sys.stdout.write("%s\t%s\n" % (k, v))
     else:
         if os.path.isdir(entry.filename):
-            sys.stderr.write(_(u"Error: match found but is a directory\n"))
+            sys.stderr.write(_("Error: match found but is a directory\n"))
             sys.exit(2)
         fp = entry.open()
         try:
@@ -281,9 +281,9 @@ def cmd_remove(store, args):
             nb = sum(1 for e in entries)
             if nb:
                 sys.stderr.write(_(
-                        u"Error: not removing files unconditionally unless -f "
-                        u"is given\n"
-                        u"(command would have removed {nb} files)\n",
+                        "Error: not removing files unconditionally unless -f "
+                        "is given\n"
+                        "(command would have removed {nb} files)\n",
                         nb=nb))
                 sys.exit(1)
         for e in entries:
@@ -296,14 +296,14 @@ def cmd_verify(store, args):
     This command accepts no argument.
     """
     if args:
-        sys.stderr.write(_(u"verify command accepts no argument\n"))
+        sys.stderr.write(_("verify command accepts no argument\n"))
         sys.exit(1)
     store.verify()
 
 
 def cmd_view(store, args):
     if args:
-        sys.stderr.write(_(u"view command accepts no argument\n"))
+        sys.stderr.write(_("view command accepts no argument\n"))
         sys.exit(1)
     from .viewer import run_viewer
     run_viewer(store)
@@ -323,16 +323,16 @@ def main(args):
     warnings.filterwarnings('always', category=UsageWarning)
 
     usage = _(
-            u"usage: {bin} <store> create\n"
-            u"   or: {bin} <store> add <filename> [key1=value1] [...]\n"
-            u"   or: {bin} <store> write [key1=value1] [...]\n"
-            u"   or: {bin} <store> query [-d] [-t] [key1=value1] [...]\n"
-            u"   or: {bin} <store> print [-m] [-t] <filehash> [...]\n"
-            u"   or: {bin} <store> print [-m] [-t] [key1=value1] [...]\n"
-            u"   or: {bin} <store> remove [-f] <filehash>\n"
-            u"   or: {bin} <store> remove [-f] <key1=value1> [...]\n"
-            u"   or: {bin} <store> verify\n"
-            u"   or: {bin} <store> view\n",
+            "usage: {bin} <store> create\n"
+            "   or: {bin} <store> add <filename> [key1=value1] [...]\n"
+            "   or: {bin} <store> write [key1=value1] [...]\n"
+            "   or: {bin} <store> query [-d] [-t] [key1=value1] [...]\n"
+            "   or: {bin} <store> print [-m] [-t] <filehash> [...]\n"
+            "   or: {bin} <store> print [-m] [-t] [key1=value1] [...]\n"
+            "   or: {bin} <store> remove [-f] <filehash>\n"
+            "   or: {bin} <store> remove [-f] <key1=value1> [...]\n"
+            "   or: {bin} <store> verify\n"
+            "   or: {bin} <store> view\n",
             bin='file_archive')
 
     if len(args) < 2:
@@ -346,14 +346,14 @@ def main(args):
         try:
             FileStore.create_store(store)
         except Exception as e:
-            sys.stderr.write(_(u"Can't create store: {err}\n", err=e.args[0]))
+            sys.stderr.write(_("Can't create store: {err}\n", err=e.args[0]))
             sys.exit(3)
         sys.exit(0)
 
     try:
         store = FileStore(store)
     except Exception as e:
-        sys.stderr.write(_(u"Invalid store: {err}\n", err=e.args[0]))
+        sys.stderr.write(_("Invalid store: {err}\n", err=e.args[0]))
         sys.exit(3)
 
     try:

--- a/file_archive/main.py
+++ b/file_archive/main.py
@@ -177,24 +177,24 @@ def cmd_query(store, args):
     else:
         sys.stdout.write('{\n')
         for entry in entries:
-            sys.stdout.write("    '%s': {\n" % entry['hash'])
+            sys.stdout.write('    "%s": {\n' % entry['hash'])
             for k, v in entry.metadata.items():
                 if k == 'hash':
                     continue
                 if types:
                     if isinstance(v, int_types):
-                        v = "{'type': 'int', 'value': %d}" % v
+                        v = '{"type": "int", "value": %d}' % v
                     else:  # isinstance(v, string_types):
                         assert isinstance(v, unicode_type)
-                        v = "{'type': 'str', 'value': u%s}" % quote_str(v)
+                        v = '{"type": "str", "value": %s}' % quote_str(v)
                 else:
                     if isinstance(v, int_types):
                         v = '%d' % v
                     else:  # isinstance(v, string_types):
                         assert isinstance(v, unicode_type)
-                        v = "u%s" % quote_str(v)
+                        v = quote_str(v)
                 k = quote_str(k)
-                sys.stdout.write("        u%s: %s,\n" % (k, v))
+                sys.stdout.write("        %s: %s,\n" % (k, v))
             sys.stdout.write('    },\n')
         sys.stdout.write('}\n')
 

--- a/file_archive/main.py
+++ b/file_archive/main.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import locale
 import os
 import sys

--- a/file_archive/parser.py
+++ b/file_archive/parser.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 from tdparser import Lexer, Parser, Token, ParserError
 from tdparser.topdown import EndToken
 

--- a/file_archive/trans.py
+++ b/file_archive/trans.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import gettext
 import locale
 import pkg_resources

--- a/file_archive/viewer.py
+++ b/file_archive/viewer.py
@@ -76,7 +76,7 @@ class MetadataItem(FileItem):
 
 
 class StoreViewerWindow(QtGui.QMainWindow):
-    WINDOW_TITLE = _(u"file_archive viewer")
+    WINDOW_TITLE = _("file_archive viewer")
 
     MAX_RESULTS = 100
 
@@ -92,13 +92,13 @@ class StoreViewerWindow(QtGui.QMainWindow):
 
         # Input line for the query
         self._input = QtGui.QLineEdit()
-        self._input.setPlaceholderText(_(u"Enter query here"))
+        self._input.setPlaceholderText(_("Enter query here"))
         self._input.returnPressed.connect(self._search)
         self._input.textEdited.connect(lambda t: self._set_needs_refresh())
         searchbar.addWidget(self._input)
 
         # Search button
-        self._searchbutton = QtGui.QPushButton(_(u"Search"))
+        self._searchbutton = QtGui.QPushButton(_("Search"))
         self._searchbutton.clicked.connect(self._search)
         self._set_needs_refresh(True)
         searchbar.addWidget(self._searchbutton)
@@ -108,7 +108,7 @@ class StoreViewerWindow(QtGui.QMainWindow):
         # Result view, as a tree with metadata
         self._result_tree = QtGui.QTreeWidget()
         self._result_tree.setColumnCount(3)
-        self._result_tree.setHeaderLabels([_(u"Key"), _(u"Value"), _(u"Type")])
+        self._result_tree.setHeaderLabels([_("Key"), _("Value"), _("Type")])
         self._result_tree.itemSelectionChanged.connect(self._selection_changed)
         results.addWidget(self._result_tree)
 
@@ -135,7 +135,7 @@ class StoreViewerWindow(QtGui.QMainWindow):
         # Open button; uses the system to choose the program to open with
         # (on Windows, might ask you what to use every time because of filename
         # scheme)
-        open_button = QtGui.QPushButton(_(u"Open"))
+        open_button = QtGui.QPushButton(_("Open"))
         if openfile is not None:
             open_button.clicked.connect(self._openfile)
             buttons.append(('single', open_button))
@@ -143,7 +143,7 @@ class StoreViewerWindow(QtGui.QMainWindow):
             open_button.setEnabled(False)
 
         # Delete button, removes what's selected (with confirmation)
-        remove_button = QtGui.QPushButton(_(u"Delete"))
+        remove_button = QtGui.QPushButton(_("Delete"))
         remove_button.clicked.connect(self._delete)
         buttons.append(('multi', remove_button))
 
@@ -173,7 +173,7 @@ class StoreViewerWindow(QtGui.QMainWindow):
             try:
                 entries = [self.store.get(h)]
             except KeyError:
-                error = _(u"hash '{h}' not found", h=h)
+                error = _("hash '{h}' not found", h=h)
 
         else:
             try:
@@ -206,7 +206,7 @@ class StoreViewerWindow(QtGui.QMainWindow):
 
                 if i >= self.MAX_RESULTS:
                     last_item = QtGui.QTreeWidgetItem(
-                            [_(u"... stripped after {nb} results...",
+                            [_("... stripped after {nb} results...",
                                nb=self.MAX_RESULTS)])
                     f = last_item.font(0)
                     f.setBold(True)
@@ -217,7 +217,7 @@ class StoreViewerWindow(QtGui.QMainWindow):
                                                                 True)
                     break
             if self._result_tree.topLevelItemCount() == 0:
-                w = QtGui.QTreeWidgetItem([_(u"No matches")])
+                w = QtGui.QTreeWidgetItem([_("No matches")])
                 self._result_tree.addTopLevelItem(w)
                 self._result_tree.setFirstItemColumnSpanned(w, True)
             self._result_tree.expandAll()
@@ -246,11 +246,11 @@ class StoreViewerWindow(QtGui.QMainWindow):
             return
         confirm = QtGui.QMessageBox.question(
                 self,
-                _(u"Are you sure?"),
-                _n(u"You are about to delete {num} entry from the store. "
-                   u"Please confirm.",
-                   u"You are about to delete {num} entries from the store. "
-                   u"Please confirm.",
+                _("Are you sure?"),
+                _n("You are about to delete {num} entry from the store. "
+                   "Please confirm.",
+                   "You are about to delete {num} entries from the store. "
+                   "Please confirm.",
                    len(items),
                    num=len(items)),
                 QtGui.QMessageBox.Ok | QtGui.QMessageBox.Cancel,

--- a/file_archive/viewer.py
+++ b/file_archive/viewer.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import platform
 import subprocess
 import sys

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import locale
 import os
 import sys

--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -18,7 +18,7 @@ if not top_level in sys.path:
 sys.path.append(start_dir)
 
 
-locale.setlocale(locale.LC_ALL, 'C')
+locale.setlocale(locale.LC_ALL, str('C'))
 
 
 class Program(unittest.TestProgram):

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import contextlib
 import os
 import shutil

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import os
 import platform
 import shutil

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -12,7 +12,7 @@ except ImportError:
     import unittest
 
 import file_archive
-from file_archive.compat import StringIO
+from file_archive.compat import BytesIO
 
 from .common import temp_dir, temp_warning_filter
 
@@ -26,17 +26,18 @@ class TestInternals(unittest.TestCase):
     """
     def test_buffered_reader(self):
         def chunks(s):
-            return list(file_archive.BufferedReader(StringIO(s)))
+            return list(file_archive.BufferedReader(BytesIO(s)))
 
         old_chunk_size = file_archive.CHUNKSIZE
         file_archive.CHUNKSIZE = 4
         try:
-            self.assertEqual(chunks(''), [])
-            self.assertEqual(chunks('a'), ['a'])
-            self.assertEqual(chunks('abcd'), ['abcd'])
-            self.assertEqual(chunks('abcde'), ['abcd', 'e'])
-            self.assertEqual(chunks('abcdefghijkl'), ['abcd', 'efgh', 'ijkl'])
-            self.assertEqual(chunks('abcdefghij'), ['abcd', 'efgh', 'ij'])
+            self.assertEqual(chunks(b''), [])
+            self.assertEqual(chunks(b'a'), [b'a'])
+            self.assertEqual(chunks(b'abcd'), [b'abcd'])
+            self.assertEqual(chunks(b'abcde'), [b'abcd', b'e'])
+            self.assertEqual(chunks(b'abcdefghijkl'),
+                             [b'abcd', b'efgh', b'ijkl'])
+            self.assertEqual(chunks(b'abcdefghij'), [b'abcd', b'efgh', b'ij'])
         finally:
             file_archive.CHUNKSIZE = old_chunk_size
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -158,9 +158,9 @@ class TestParseQuery(unittest.TestCase):
         strs = ['type=a file',
                 'month=str:october',
                 'time=str:11:20']
-        dct = {'type': {'type': 'str', 'equal': u'a file'},
-               'month': {'type': 'str', 'equal': u'october'},
-               'time': {'type': 'str', 'equal': u'11:20'}}
+        dct = {'type': {'type': 'str', 'equal': 'a file'},
+               'month': {'type': 'str', 'equal': 'october'},
+               'time': {'type': 'str', 'equal': '11:20'}}
         self.assertEqual(file_archive.main.parse_query_metadata(strs),
                          (None, dct))
 
@@ -189,9 +189,9 @@ class TestParseNewData(unittest.TestCase):
         self.assertEqual(file_archive.main.parse_new_metadata(
                 ['type=a file', 'month=str:october',
                  'time=str:11:40', 'year=int:2013']),
-                {'type': {'type': 'str', 'value': u'a file'},
-                 'month': {'type': 'str', 'value': u'october'},
-                 'time': {'type': 'str', 'value': u'11:40'},
+                {'type': {'type': 'str', 'value': 'a file'},
+                 'month': {'type': 'str', 'value': 'october'},
+                 'time': {'type': 'str', 'value': '11:40'},
                  'year': {'type': 'int', 'value': 2013}})
 
     def test_errors(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -125,6 +125,17 @@ class TestStore(unittest.TestCase):
                 h1: {'tag': 'testfile', 'test': 1},
                 h2: {'tag': 'other', 'test': 2},
             })
+        self.assertEqual(out,
+                         ['{',
+                          '    "de0ccf54a9c1de0d9fdbf23f71a64762448057d0": {',
+                          '        "tag": "other",',
+                          '        "test": 2',
+                          '    },',
+                          '    "fce92fa2647153f7d696a3c1884d732290273102": {',
+                          '        "tag": "testfile",',
+                          '        "test": 1',
+                          '    }',
+                          '}'])
 
     # TODO : print
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import contextlib
 import os
 import sys

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,3 +1,5 @@
+from __future__ import division, unicode_literals
+
 import tdparser
 try:
     import unittest2 as unittest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py26,py27,py33,coverage
+envlist=py26,py27,py32,py33,coverage
 
 [testenv]
 commands=python tests


### PR DESCRIPTION
Brings back 3.2 support.

I don't like this because it means we can't use the 'u' prefix anywhere. It also complicates the tests a bit.
